### PR TITLE
fix: build system alm.platform

### DIFF
--- a/scripts/site_scons/alm/platform.py
+++ b/scripts/site_scons/alm/platform.py
@@ -49,8 +49,8 @@ def is_os(tgt_os, os_list):
 
     return False
 
-def is_running_os(*oslist):
-    is_os(get_os_name(), os_list)
+def is_running_os(*os_list):
+    return is_os(get_os_name(), os_list)
 
 class AlmPlatform(object):
     def __init__(self):

--- a/scripts/site_scons/alm/variables.py
+++ b/scripts/site_scons/alm/variables.py
@@ -27,11 +27,10 @@ from SCons.Variables import Variables
 from SCons.Script import ARGUMENTS, PathVariable, GetOption
 
 import shlex
-import platform
+from .platform import is_running_os
 
 def variable_shlex_splitter(val):
-    parse_mode = 'other' if platform.is_running_os('windows') else 'posix'
-    return shlex.split(val, posix=(parse_mode == 'posix'))
+    return shlex.split(val, posix=not is_running_os('windows'))
 
 class AlmVariables(Variables):
     def __init__(self):


### PR DESCRIPTION
Hello,

There was an error in scripts/site_scons/alm/variable.py where standard platform was imported instead of local alm.platform.

The fix revealed that `is_running_os` was missing a return and had a typo in the parameter name.