### PR TITLE
fix: use LDFLAGS in accordance to alm.variable

### DIFF
--- a/scripts/site_scons/alm/compiler/__init__.py
+++ b/scripts/site_scons/alm/compiler/__init__.py
@@ -129,7 +129,7 @@ class Compiler:
         env['CC']        = self.Cmd()
         env['CXX']       = self.CxxCmd()
         env['CFLAGS']    = self.CFlags()
-        env['LINKFLAGS'] = self.LDFlags()
+        env['LDFLAGS'] = self.LDFlags()
 
         env['CCVERSION'] = self.Version()
         env['CXXVERSION'] = self.Version()
@@ -153,8 +153,8 @@ class Compiler:
         if 'ALM_CFLAGS' in keys:
             self.UpdateCFlags(env['ALM_CFLAGS'])
 
-        if 'ALM_LINKFLAGS' in keys:
-            self.UpdateLDFlags(env['ALM_LINKFLAGS'])
+        if 'ALM_LDFLAGS' in keys:
+            self.UpdateLDFlags(env['ALM_LDFLAGS'])
 
     def __fixup_from_env(self):
         '''


### PR DESCRIPTION
Hi, there was an incoherence between `alm.variables` and `alm.compiler` that caused `ALM_LDFLAGS` and `ALM_LINKFLAGS` to be ignored. This fix proposes to use `ALM_LDFLAGS` everywhere instead as it was the most used already.