### PR TITLE
Add optional __declspec(dllimport) to amd_* libm functions, for faster speed

### DIFF
--- a/include/external/amdlibm.h
+++ b/include/external/amdlibm.h
@@ -166,6 +166,44 @@ agreements with respect to the subject matter of this Agreement.
 #define __AMDLIBM_H__
 
 
+/*
+ *  ALM_API
+ *  --------
+ *  Optional decoration that marks public AOCL-LibM entry points as
+ *  imported from libalm.dll on Windows. Without this attribute, taking
+ *  the address of an amd_* function (or storing it in a function
+ *  pointer in a hot loop) captures the local import-thunk address;
+ *  every call then pays an extra indirect jmp through the IAT. For
+ *  sub-3 ns functions like amd_expf that extra hop is ~15-30% of the
+ *  per-call cost. Decorating the prototypes with __declspec(dllimport)
+ *  tells MSVC / clang-cl to emit the optimized `movq __imp_*` form,
+ *  which dereferences the IAT slot once and stores the actual function
+ *  address - giving a single indirect call per invocation.
+ *
+ *  Opt-in (default is unchanged - no decoration):
+ *      Define ALM_DLLIMPORT before #include <amdlibm.h> when linking
+ *      dynamically against libalm.dll on Windows to enable the faster
+ *      call sequence. Safe to leave undefined: behavior is identical
+ *      to previous releases (no breaking change for callers that link
+ *      against libalm-static.lib or that depend on the existing
+ *      codegen).
+ *
+ *  On non-Windows platforms ALM_API is always empty regardless of
+ *  ALM_DLLIMPORT.
+ *
+ *  Exports themselves are controlled by scripts/libalm.def, so this
+ *  header does not emit __declspec(dllexport); only the consumer-side
+ *  import attribute is added here.
+ */
+#ifndef ALM_API
+  #if (defined(_WIN32) || defined(_WIN64)) && defined(ALM_DLLIMPORT)
+    #define ALM_API __declspec(dllimport)
+  #else
+    #define ALM_API
+  #endif
+#endif
+
+
 #include <complex.h>
 #include "amdlibm_vec.h"
 
@@ -207,39 +245,39 @@ extern "C" {
    * @param x Input angle in radians.
    * @return Sine of x.
    */
-  double amd_sin (double x);
+  ALM_API double amd_sin (double x);
   /**
    * @brief Computes the sine of a single-precision angle.
    * @param x Input angle in radians.
    * @return Sine of x.
    */
-  float amd_sinf (float x);
-  
+  ALM_API float amd_sinf (float x);
+
   /**
    * @brief Computes the cosine of a double-precision angle.
    * @param x Input angle in radians.
    * @return Cosine of x.
    */
-  double amd_cos (double x);
+  ALM_API double amd_cos (double x);
   /**
    * @brief Computes the cosine of a single-precision angle.
    * @param x Input angle in radians.
    * @return Cosine of x.
    */
-  float amd_cosf (float x);
+  ALM_API float amd_cosf (float x);
 
   /**
    * @brief Computes the tangent of a double-precision angle.
    * @param x Input angle in radians.
    * @return Tangent of x.
    */
-  double amd_tan (double x);
+  ALM_API double amd_tan (double x);
   /**
    * @brief Computes the tangent of a single-precision angle.
    * @param x Input angle in radians.
    * @return Tangent of x.
    */
-  float amd_tanf (float x);
+  ALM_API float amd_tanf (float x);
 
 /* Inverse Trigonometric */
   /**
@@ -247,39 +285,39 @@ extern "C" {
    * @param x Input value.
    * @return Arc-sine of x in radians.
    */
-  double amd_asin (double x);
+  ALM_API double amd_asin (double x);
   /**
    * @brief Computes the principal value of the arc-sine of a single-precision value.
    * @param x Input value.
    * @return Arc-sine of x in radians.
    */
-  float amd_asinf (float x);
+  ALM_API float amd_asinf (float x);
 
   /**
    * @brief Computes the principal value of the arc-cosine of a double-precision value.
    * @param x Input value.
    * @return Arc-cosine of x in radians.
    */
-  double amd_acos (double x);
+  ALM_API double amd_acos (double x);
   /**
    * @brief Computes the principal value of the arc-cosine of a single-precision value.
    * @param x Input value.
    * @return Arc-cosine of x in radians.
    */
-  float amd_acosf (float x);
+  ALM_API float amd_acosf (float x);
 
   /**
    * @brief Computes the principal value of the arc-tangent of a double-precision value.
    * @param x Input value.
    * @return Arc-tangent of x in radians.
    */
-  double amd_atan (double x);
+  ALM_API double amd_atan (double x);
   /**
    * @brief Computes the principal value of the arc-tangent of a single-precision value.
    * @param x Input value.
    * @return Arc-tangent of x in radians.
    */
-  float amd_atanf (float x);
+  ALM_API float amd_atanf (float x);
 
   /**
    * @brief Computes the arc-tangent of the quotient of two double-precision values.
@@ -287,14 +325,14 @@ extern "C" {
    * @param y Second argument.
    * @return Angle in radians, using the signs of both arguments to determine the correct quadrant.
    */
-  double amd_atan2 (double x, double y);
+  ALM_API double amd_atan2 (double x, double y);
   /**
    * @brief Computes the arc-tangent of the quotient of two single-precision values.
    * @param x First argument.
    * @param y Second argument.
    * @return Angle in radians, using the signs of both arguments to determine the correct quadrant.
    */
-  float amd_atan2f (float x, float y);
+  ALM_API float amd_atan2f (float x, float y);
 
   /**
    * @brief Computes both sine and cosine of a double-precision angle.
@@ -302,14 +340,14 @@ extern "C" {
    * @param s Output pointer for sine of x.
    * @param c Output pointer for cosine of x.
    */
-  void amd_sincos (double x, double *s, double *c);
+  ALM_API void amd_sincos (double x, double *s, double *c);
   /**
    * @brief Computes both sine and cosine of a single-precision angle.
    * @param x Input angle in radians.
    * @param s Output pointer for sine of x.
    * @param c Output pointer for cosine of x.
    */
-  void amd_sincosf (float x, float *s, float *c);
+  ALM_API void amd_sincosf (float x, float *s, float *c);
 
 /* Hyperbolic */
   /**
@@ -317,39 +355,39 @@ extern "C" {
    * @param x Input value.
    * @return Hyperbolic sine of x.
    */
-  double amd_sinh (double x);
+  ALM_API double amd_sinh (double x);
   /**
    * @brief Computes the hyperbolic sine of a single-precision value.
    * @param x Input value.
    * @return Hyperbolic sine of x.
    */
-  float amd_sinhf (float x);
+  ALM_API float amd_sinhf (float x);
 
   /**
    * @brief Computes the hyperbolic cosine of a double-precision value.
    * @param x Input value.
    * @return Hyperbolic cosine of x.
    */
-  double amd_cosh (double x);
+  ALM_API double amd_cosh (double x);
   /**
    * @brief Computes the hyperbolic cosine of a single-precision value.
    * @param x Input value.
    * @return Hyperbolic cosine of x.
    */
-  float amd_coshf (float x);
+  ALM_API float amd_coshf (float x);
 
   /**
    * @brief Computes the hyperbolic tangent of a double-precision value.
    * @param x Input value.
    * @return Hyperbolic tangent of x.
    */
-  double amd_tanh (double x);
+  ALM_API double amd_tanh (double x);
   /**
    * @brief Computes the hyperbolic tangent of a single-precision value.
    * @param x Input value.
    * @return Hyperbolic tangent of x.
    */
-  float amd_tanhf (float x);
+  ALM_API float amd_tanhf (float x);
 
 /* Inverse Hyperbolic */
   /**
@@ -357,40 +395,40 @@ extern "C" {
    * @param x Input value.
    * @return Inverse hyperbolic sine of x.
    */
-  double amd_asinh (double x);
+  ALM_API double amd_asinh (double x);
   /**
    * @brief Computes the inverse hyperbolic sine of a single-precision value.
    * @param x Input value.
    * @return Inverse hyperbolic sine of x.
    */
-  float amd_asinhf (float x);
+  ALM_API float amd_asinhf (float x);
 
   /**
    * @brief Computes the inverse hyperbolic cosine of a double-precision value.
    * @param x Input value.
    * @return Inverse hyperbolic cosine of x.
    */
-  double amd_acosh (double x);
+  ALM_API double amd_acosh (double x);
   /**
    * @brief Computes the inverse hyperbolic cosine of a single-precision value.
    * @param x Input value.
    * @return Inverse hyperbolic cosine of x.
    */
-  float amd_acoshf (float x);
-  
+  ALM_API float amd_acoshf (float x);
+
 
   /**
    * @brief Computes the inverse hyperbolic tangent of a double-precision value.
    * @param x Input value.
    * @return Inverse hyperbolic tangent of x.
    */
-  double amd_atanh (double x);
+  ALM_API double amd_atanh (double x);
   /**
    * @brief Computes the inverse hyperbolic tangent of a single-precision value.
    * @param x Input value.
    * @return Inverse hyperbolic tangent of x.
    */
-  float amd_atanhf (float x);
+  ALM_API float amd_atanhf (float x);
 
 /* Exponential */
   /**
@@ -398,52 +436,52 @@ extern "C" {
    * @param x Exponent.
    * @return e^x.
    */
-  double amd_exp (double x);
+  ALM_API double amd_exp (double x);
   /**
    * @brief Computes e raised to a single-precision power.
    * @param x Exponent.
    * @return e^x.
    */
-  float amd_expf (float x);
+  ALM_API float amd_expf (float x);
 
   /**
    * @brief Computes 2 raised to a double-precision exponent.
    * @param x Exponent.
    * @return 2^x.
    */
-  double amd_exp2 (double x);
+  ALM_API double amd_exp2 (double x);
   /**
    * @brief Computes 2 raised to a single-precision exponent.
    * @param x Exponent.
    * @return 2^x.
    */
-  float amd_exp2f (float x);
+  ALM_API float amd_exp2f (float x);
 
   /**
    * @brief Computes 10 raised to a double-precision exponent.
    * @param x Exponent.
    * @return 10^x.
    */
-  double amd_exp10 (double x);
+  ALM_API double amd_exp10 (double x);
   /**
    * @brief Computes 10 raised to a single-precision exponent.
    * @param x Exponent.
    * @return 10^x.
    */
-  float amd_exp10f (float x);
+  ALM_API float amd_exp10f (float x);
 
   /**
    * @brief Computes exp(x) - 1 with reduced error for small x (double-precision).
    * @param x Input value.
    * @return exp(x) - 1.
    */
-  double amd_expm1 (double x);
+  ALM_API double amd_expm1 (double x);
   /**
    * @brief Computes exp(x) - 1 with reduced error for small x (single-precision).
    * @param x Input value.
    * @return exp(x) - 1.
    */
-  float amd_expm1f (float x);
+  ALM_API float amd_expm1f (float x);
 
 /* Logarithmic */
   /**
@@ -451,52 +489,52 @@ extern "C" {
    * @param x Input value.
    * @return Natural logarithm of x.
    */
-  double amd_log (double x);
+  ALM_API double amd_log (double x);
   /**
    * @brief Computes the natural logarithm (base e) of a single-precision value.
    * @param x Input value.
    * @return Natural logarithm of x.
    */
-  float amd_logf (float x);
+  ALM_API float amd_logf (float x);
 
   /**
    * @brief Computes the base-2 logarithm of a double-precision value.
    * @param x Input value.
    * @return Base-2 logarithm of x.
    */
-  double amd_log2 (double x);
+  ALM_API double amd_log2 (double x);
   /**
    * @brief Computes the base-2 logarithm of a single-precision value.
    * @param x Input value.
    * @return Base-2 logarithm of x.
    */
-  float amd_log2f (float x);
+  ALM_API float amd_log2f (float x);
 
   /**
    * @brief Computes the base-10 logarithm of a double-precision value.
    * @param x Input value.
    * @return Base-10 logarithm of x.
    */
-  double amd_log10 (double x);
+  ALM_API double amd_log10 (double x);
   /**
    * @brief Computes the base-10 logarithm of a single-precision value.
    * @param x Input value.
    * @return Base-10 logarithm of x.
    */
-  float amd_log10f (float x);
+  ALM_API float amd_log10f (float x);
 
   /**
    * @brief Computes log(1 + x) with reduced error for small x (double-precision).
    * @param x Input value.
    * @return log(1 + x).
    */
-  double amd_log1p (double x);
+  ALM_API double amd_log1p (double x);
   /**
    * @brief Computes log(1 + x) with reduced error for small x (single-precision).
    * @param x Input value.
    * @return log(1 + x).
    */
-  float amd_log1pf (float x);
+  ALM_API float amd_log1pf (float x);
 
 /* Power & Root */
   /**
@@ -505,40 +543,40 @@ extern "C" {
    * @param y Exponent.
    * @return x raised to the power y.
    */
-  double amd_pow (double x, double y);
+  ALM_API double amd_pow (double x, double y);
   /**
    * @brief Computes the result of raising a single-precision base to a single-precision exponent..
    * @param x Base.
    * @param y Exponent.
    * @return x raised to the power y.
    */
-  float amd_powf (float x, float y);
+  ALM_API float amd_powf (float x, float y);
 
   /**
    * @brief Computes the square root of a double-precision value.
    * @param x Input value.
    * @return Square root of x.
    */
-  double amd_sqrt (double x);
+  ALM_API double amd_sqrt (double x);
   /**
    * @brief Computes the square root of a single-precision value.
    * @param x Input value.
    * @return Square root of x.
    */
-  float amd_sqrtf (float x);
+  ALM_API float amd_sqrtf (float x);
 
   /**
    * @brief Computes the cube root of a double-precision value.
    * @param x Input value.
    * @return Cube root of x.
    */
-  double amd_cbrt (double x);
+  ALM_API double amd_cbrt (double x);
   /**
    * @brief Computes the cube root of a single-precision value.
    * @param x Input value.
    * @return Cube root of x.
    */
-  float amd_cbrtf (float x);
+  ALM_API float amd_cbrtf (float x);
 
 /* Error */
   /**
@@ -546,13 +584,13 @@ extern "C" {
    * @param x Input value.
    * @return erf(x).
    */
-  double amd_erf (double x);
+  ALM_API double amd_erf (double x);
   /**
    * @brief Computes the Gaussian error function for a single-precision value.
    * @param x Input value.
    * @return erf(x).
    */
-  float amd_erff (float x);
+  ALM_API float amd_erff (float x);
 
 /* Inverse Error */
   /**
@@ -560,7 +598,7 @@ extern "C" {
    * @param x Input value.
    * @return erfinv(x).
    */
-  double amd_erfinv (double x);
+  ALM_API double amd_erfinv (double x);
 
 /* Complementary Error */
   /**
@@ -568,13 +606,13 @@ extern "C" {
    * @param x Input value.
    * @return erfc(x).
    */
-  double amd_erfc (double x);
+  ALM_API double amd_erfc (double x);
   /**
    * @brief Computes the complementary error function for a single-precision value.
    * @param x Input value.
    * @return erfcf(x).
    */
-  float amd_erfcf (float x);
+  ALM_API float amd_erfcf (float x);
 
 /* Special */
   /**
@@ -582,14 +620,14 @@ extern "C" {
    * @param x Input value.
    * @return cdfnorm(x).
    */
-  double amd_cdfnorm (double x);
+  ALM_API double amd_cdfnorm (double x);
 
   /**
    * @brief Computes the inverse cumulative normal distribution function
    * @param x Input value.
    * @return cdfnorminv(x).
    */
-  double amd_cdfnorminv (double x);
+  ALM_API double amd_cdfnorminv (double x);
 
   /* Inverse Complementary Error */
   /**
@@ -597,7 +635,7 @@ extern "C" {
    * @param x Input value.
    * @return erfcinv(x).
    */
-  double amd_erfcinv (double x);
+  ALM_API double amd_erfcinv (double x);
 
 /* Remainder */
   /**
@@ -606,14 +644,14 @@ extern "C" {
    * @param y Denominator.
    * @return Remainder of x divided by y.
    */
-  double amd_fmod (double x, double y);
+  ALM_API double amd_fmod (double x, double y);
   /**
    * @brief Computes the remainder of the division operation x/y (single-precision).
    * @param x Numerator.
    * @param y Denominator.
    * @return Remainder of x divided by y.
    */
-  float amd_fmodf (float x, float y);
+  ALM_API float amd_fmodf (float x, float y);
 
   /**
    * @brief Computes the IEEE 754-style remainder of x with respect to y (double-precision).
@@ -621,14 +659,14 @@ extern "C" {
    * @param y Denominator.
    * @return Remainder value.
    */
-  double amd_remainder (double x, double y);
+  ALM_API double amd_remainder (double x, double y);
   /**
    * @brief Computes the IEEE 754-style remainder of x with respect to y (single-precision).
    * @param x Numerator.
    * @param y Denominator.
    * @return Remainder value.
    */
-  float amd_remainderf (float x, float y);
+  ALM_API float amd_remainderf (float x, float y);
 
   /**
    * @brief Computes the remainder and part of the quotient for double-precision inputs.
@@ -637,7 +675,7 @@ extern "C" {
    * @param quo Output pointer receiving a part of the quotient.
    * @return Remainder value.
    */
-  double amd_remquo (double x, double y, int *quo);
+  ALM_API double amd_remquo (double x, double y, int *quo);
   /**
    * @brief Computes the remainder and part of the quotient for single-precision inputs.
    * @param x Numerator.
@@ -645,7 +683,7 @@ extern "C" {
    * @param quo Output pointer receiving a part of the quotient.
    * @return Remainder value.
    */
-  float amd_remquof (float x, float y, int *quo);
+  ALM_API float amd_remquof (float x, float y, int *quo);
 
 /* Maximum, Minimum & Difference */
   /**
@@ -654,14 +692,14 @@ extern "C" {
    * @param y Second value.
    * @return Maximum of x and y.
    */
-  double amd_fmax  (double x, double y);
+  ALM_API double amd_fmax  (double x, double y);
   /**
    * @brief Returns the larger of two single-precision values.
    * @param x First value.
    * @param y Second value.
    * @return Maximum of x and y.
    */
-  float amd_fmaxf (float x, float y);
+  ALM_API float amd_fmaxf (float x, float y);
 
   /**
    * @brief Returns the smaller of two double-precision values.
@@ -669,14 +707,14 @@ extern "C" {
    * @param y Second value.
    * @return Minimum of x and y.
    */
-  double amd_fmin (double x, double y);
+  ALM_API double amd_fmin (double x, double y);
   /**
    * @brief Returns the smaller of two single-precision values.
    * @param x First value.
    * @param y Second value.
    * @return Minimum of x and y.
    */
-  float amd_fminf (float x, float y);
+  ALM_API float amd_fminf (float x, float y);
 
   /**
    * @brief Computes the positive difference max(x - y, 0) for double-precision values.
@@ -684,14 +722,14 @@ extern "C" {
    * @param y Subtrahend.
    * @return Positive difference.
    */
-  double amd_fdim (double x, double y);
+  ALM_API double amd_fdim (double x, double y);
   /**
    * @brief Computes the positive difference max(x - y, 0) for single-precision values.
    * @param x Minuend.
    * @param y Subtrahend.
    * @return Positive difference.
    */
-  float amd_fdimf (float x, float y);
+  ALM_API float amd_fdimf (float x, float y);
 
 /* Euclidean Distance */
   /**
@@ -700,14 +738,14 @@ extern "C" {
    * @param y Second value.
    * @return Euclidean norm of (x, y).
    */
-  double amd_hypot (double x, double y);
+  ALM_API double amd_hypot (double x, double y);
   /**
    * @brief Computes sqrt(x^2 + y^2) for two single-precision inputs.
    * @param x First value.
    * @param y Second value.
    * @return Euclidean norm of (x, y).
    */
-  float amd_hypotf (float x, float y);
+  ALM_API float amd_hypotf (float x, float y);
 
 /* Nearest Integer */
   /**
@@ -715,65 +753,65 @@ extern "C" {
    * @param x Input value.
    * @return Smallest integer value not less than x.
    */
-  double amd_ceil (double x);
+  ALM_API double amd_ceil (double x);
   /**
    * @brief Rounds a single-precision value upward to the nearest integer value.
    * @param x Input value.
    * @return Smallest integer value not less than x.
    */
-  float amd_ceilf (float x);
+  ALM_API float amd_ceilf (float x);
 
   /**
    * @brief Rounds a double-precision value downward to the nearest integer value.
    * @param x Input value.
    * @return Largest integer value not greater than x.
    */
-  double amd_floor (double x);
+  ALM_API double amd_floor (double x);
   /**
    * @brief Rounds a single-precision value downward to the nearest integer value.
    * @param x Input value.
    * @return Largest integer value not greater than x.
    */
-  float amd_floorf (float x);
+  ALM_API float amd_floorf (float x);
 
   /**
    * @brief Truncates a double-precision value toward zero.
    * @param x Input value.
    * @return Truncated integer value as double.
    */
-  double amd_trunc (double x);
+  ALM_API double amd_trunc (double x);
   /**
    * @brief Truncates a single-precision value toward zero.
    * @param x Input value.
    * @return Truncated integer value as float.
    */
-  float amd_truncf (float x);
+  ALM_API float amd_truncf (float x);
 
   /**
    * @brief Rounds a double-precision value to an integer value according to current rounding mode.
    * @param x Input value.
    * @return Rounded value.
    */
-  double amd_nearbyint (double x);
+  ALM_API double amd_nearbyint (double x);
   /**
    * @brief Rounds a single-precision value to an integer value according to current rounding mode.
    * @param x Input value.
    * @return Rounded value.
    */
-  float amd_nearbyintf (float x);
+  ALM_API float amd_nearbyintf (float x);
 
   /**
    * @brief Rounds a double-precision value to an integer value according to current rounding mode, as double.
    * @param x Input value.
    * @return Rounded value.
    */
-  double amd_rint (double x);
+  ALM_API double amd_rint (double x);
   /**
    * @brief Rounds a single-precision value to an integer value according to current rounding mode, as float.
    * @param x Input value.
    * @return Rounded value.
    */
-  float amd_rintf (float x);
+  ALM_API float amd_rintf (float x);
 
   /**
    * @brief Rounds a double-precision value to a long int according to current rounding mode.
@@ -806,13 +844,13 @@ extern "C" {
    * @param f Input value.
    * @return Rounded value.
    */
-  double amd_round (double f);
+  ALM_API double amd_round (double f);
   /**
    * @brief Rounds a single-precision value to the nearest integer, halfway cases away from zero.
    * @param f Input value.
    * @return Rounded value.
    */
-  float amd_roundf (float f);
+  ALM_API float amd_roundf (float f);
 
   /**
    * @brief Rounds a double-precision value to the nearest integer and returns it as long int.
@@ -846,13 +884,13 @@ extern "C" {
    * @param x Input value.
    * @return |x|.
    */
-  double amd_fabs (double x);
+  ALM_API double amd_fabs (double x);
   /**
    * @brief Computes the absolute value of a single-precision number.
    * @param x Input value.
    * @return |x|.
    */
-  float amd_fabsf (float x);
+  ALM_API float amd_fabsf (float x);
 
   /**
    * @brief Decomposes a double-precision number into fractional and integer parts.
@@ -860,14 +898,14 @@ extern "C" {
    * @param iptr Output pointer to receive integer part.
    * @return Fractional part of x.
    */
-  double amd_modf (double x, double *iptr);
+  ALM_API double amd_modf (double x, double *iptr);
   /**
    * @brief Decomposes a single-precision number into fractional and integer parts.
    * @param x Input value.
    * @param iptr Output pointer to receive integer part.
    * @return Fractional part of x.
    */
-  float amd_modff (float x, float *iptr);
+  ALM_API float amd_modff (float x, float *iptr);
 
   /**
    * @brief Decomposes a double-precision value into normalized fraction and exponent.
@@ -875,14 +913,14 @@ extern "C" {
    * @param exp Output pointer to receive exponent.
    * @return Normalized fraction.
    */
-  double amd_frexp (double value, int *exp);
+  ALM_API double amd_frexp (double value, int *exp);
   /**
    * @brief Decomposes a single-precision value into normalized fraction and exponent.
    * @param value Input value.
    * @param exp Output pointer to receive exponent.
    * @return Normalized fraction.
    */
-  float amd_frexpf (float value, int *exp);
+  ALM_API float amd_frexpf (float value, int *exp);
 
   /**
    * @brief Produces a value with the magnitude of x and the sign of y (double-precision).
@@ -890,40 +928,40 @@ extern "C" {
    * @param y Sign source.
    * @return Value with magnitude of x and sign of y.
    */
-  double amd_copysign (double x, double y);
+  ALM_API double amd_copysign (double x, double y);
   /**
    * @brief Produces a value with the magnitude of x and the sign of y (single-precision).
    * @param x Magnitude source.
    * @param y Sign source.
    * @return Value with magnitude of x and sign of y.
    */
-  float amd_copysignf (float x, float y);
+  ALM_API float amd_copysignf (float x, float y);
 
   /**
    * @brief Generates a quiet NaN (double-precision) with an optional tag.
    * @param tagp Implementation-defined tag string.
    * @return Quiet NaN.
    */
-  double amd_nan (const char *tagp);
+  ALM_API double amd_nan (const char *tagp);
   /**
    * @brief Generates a quiet NaN (single-precision) with an optional tag.
    * @param tagp Implementation-defined tag string.
    * @return Quiet NaN.
    */
-  float amd_nanf (const char *tagp);
+  ALM_API float amd_nanf (const char *tagp);
 
   /**
    * @brief Tests if a double-precision value is finite (not infinite or NaN).
    * @param x Input value.
    * @return Non-zero if finite, zero otherwise.
    */
-  int amd_finite (double x);
+  ALM_API int amd_finite (double x);
   /**
    * @brief Tests if a single-precision value is finite (not infinite or NaN).
    * @param x Input value.
    * @return Non-zero if finite, zero otherwise.
    */
-  int amd_finitef (float x);
+  ALM_API int amd_finitef (float x);
 
   /**
    * @brief Multiplies a double-precision floating-point number by 2 raised to exp.
@@ -931,14 +969,14 @@ extern "C" {
    * @param exp Exponent of two.
    * @return x * 2^exp.
    */
-  double amd_ldexp (double x, int exp);
+  ALM_API double amd_ldexp (double x, int exp);
   /**
    * @brief Multiplies a single-precision floating-point number by 2 raised to exp.
    * @param x Input value.
    * @param exp Exponent of two.
    * @return x * 2^exp.
    */
-  float amd_ldexpf (float x, int exp);
+  ALM_API float amd_ldexpf (float x, int exp);
 
   /**
    * @brief Multiplies a double-precision value by 2 raised to n, using integer scaling.
@@ -946,14 +984,14 @@ extern "C" {
    * @param n Integer scale.
    * @return x * 2^n.
    */
-  double amd_scalbn (double x, int n);
+  ALM_API double amd_scalbn (double x, int n);
   /**
    * @brief Multiplies a single-precision value by 2 raised to n, using integer scaling.
    * @param x Input value.
    * @param n Integer scale.
    * @return x * 2^n.
    */
-  float amd_scalbnf (float x, int n);
+  ALM_API float amd_scalbnf (float x, int n);
 
   /**
    * @brief Multiplies a double-precision value by 2 raised to n, long integer scale.
@@ -961,40 +999,40 @@ extern "C" {
    * @param n Long integer scale.
    * @return x * 2^n.
    */
-  double amd_scalbln (double x, long int n);
+  ALM_API double amd_scalbln (double x, long int n);
   /**
    * @brief Multiplies a single-precision value by 2 raised to n, long integer scale.
    * @param x Input value.
    * @param n Long integer scale.
    * @return x * 2^n.
    */
-  float amd_scalblnf (float x, long int n);
+  ALM_API float amd_scalblnf (float x, long int n);
 
   /**
    * @brief Extracts the exponent of a double-precision floating-point value.
    * @param x Input value.
    * @return Exponent as double.
    */
-  double amd_logb (double x);
+  ALM_API double amd_logb (double x);
   /**
    * @brief Extracts the exponent of a single-precision floating-point value.
    * @param x Input value.
    * @return Exponent as float.
    */
-  float amd_logbf (float x);
+  ALM_API float amd_logbf (float x);
 
   /**
    * @brief Returns the integer exponent of a double-precision value.
    * @param x Input value.
    * @return Integer exponent.
    */
-  int amd_ilogb (double x);
+  ALM_API int amd_ilogb (double x);
   /**
    * @brief Returns the integer exponent of a single-precision value.
    * @param x Input value.
    * @return Integer exponent.
    */
-  int amd_ilogbf (float x);
+  ALM_API int amd_ilogbf (float x);
 
   /**
    * @brief Returns the next representable double after x in the direction of y.
@@ -1002,14 +1040,14 @@ extern "C" {
    * @param y Direction target.
    * @return Next representable value from x toward y.
    */
-  double amd_nextafter (double x, double y);
+  ALM_API double amd_nextafter (double x, double y);
   /**
    * @brief Returns the next representable float after x in the direction of y.
    * @param x Starting value.
    * @param y Direction target.
    * @return Next representable value from x toward y.
    */
-  float amd_nextafterf (float x, float y);
+  ALM_API float amd_nextafterf (float x, float y);
 
   /**
    * @brief Returns the next representable double after x toward long double y.
@@ -1017,14 +1055,14 @@ extern "C" {
    * @param y Direction target (long double).
    * @return Next representable value from x toward y.
    */
-  double amd_nexttoward (double x, long double y);
+  ALM_API double amd_nexttoward (double x, long double y);
   /**
    * @brief Returns the next representable float after x toward long double y.
    * @param x Starting value.
    * @param y Direction target (long double).
    * @return Next representable value from x toward y.
    */
-  float amd_nexttowardf (float x, long double y);
+  ALM_API float amd_nexttowardf (float x, long double y);
 
 /* Complex Variants */
   /**
@@ -1032,26 +1070,26 @@ extern "C" {
    * @param x Input complex value.
    * @return Complex exponential of x.
    */
-  fc64_t amd_cexp (fc64_t x);
+  ALM_API fc64_t amd_cexp (fc64_t x);
   /**
    * @brief Computes the complex exponential of a single-precision complex value.
    * @param y Input complex value.
    * @return Complex exponential of y.
    */
-  fc32_t amd_cexpf (fc32_t y);
+  ALM_API fc32_t amd_cexpf (fc32_t y);
 
   /**
    * @brief Computes the complex natural logarithm of a double-precision complex value.
    * @param x Input complex value.
    * @return Complex natural logarithm of x.
    */
-  fc64_t amd_clog (fc64_t x);
+  ALM_API fc64_t amd_clog (fc64_t x);
   /**
    * @brief Computes the complex natural logarithm of a single-precision complex value.
    * @param y Input complex value.
    * @return Complex natural logarithm of y.
    */
-  fc32_t amd_clogf (fc32_t y);
+  ALM_API fc32_t amd_clogf (fc32_t y);
 
   /**
    * @brief Raises a double-precision complex base to a double-precision complex exponent.
@@ -1059,14 +1097,14 @@ extern "C" {
    * @param y Complex exponent.
    * @return x raised to the power y.
    */
-  fc64_t amd_cpow (fc64_t x, fc64_t y);
+  ALM_API fc64_t amd_cpow (fc64_t x, fc64_t y);
   /**
    * @brief Raises a single-precision complex base to a single-precision complex exponent.
    * @param x Complex base.
    * @param y Complex exponent.
    * @return x raised to the power y.
    */
-  fc32_t amd_cpowf (fc32_t x, fc32_t y);
+  ALM_API fc32_t amd_cpowf (fc32_t x, fc32_t y);
 
 #ifdef __cplusplus
 }
@@ -1232,7 +1270,7 @@ extern "C" {
 /* Inverse Complementary Error */
   #undef erfcinv
   #define erfcinv amd_erfcinv
-  
+
 /* Special */
   #undef cdfnorm
   #define cdfnorm amd_cdfnorm

--- a/include/external/amdlibm_vec.h
+++ b/include/external/amdlibm_vec.h
@@ -165,6 +165,21 @@ agreements with respect to the subject matter of this Agreement.
 #define __AMDLIBM_VEC_H__
 
 
+/*
+ *  ALM_API decoration - see amdlibm.h for rationale. Opt-in via
+ *  ALM_DLLIMPORT; default is no decoration (no behavior change for
+ *  existing callers). Repeated here so this header can be included
+ *  standalone. Both definitions are kept in sync.
+ */
+#ifndef ALM_API
+  #if (defined(_WIN32) || defined(_WIN64)) && defined(ALM_DLLIMPORT)
+    #define ALM_API __declspec(dllimport)
+  #else
+    #define ALM_API
+  #endif
+#endif
+
+
 #include <emmintrin.h>
 #include <immintrin.h>
 
@@ -190,39 +205,39 @@ extern "C" {
    * @param x Vector of two angles in radians.
    * @return Vector of sines.
    */
-  __m128d amd_vrd2_sin (__m128d x);
+  ALM_API __m128d amd_vrd2_sin (__m128d x);
   /**
    * @brief Computes sine for four single-precision lanes.
    * @param x Vector of four angles in radians.
    * @return Vector of sines.
    */
-  __m128 amd_vrs4_sinf (__m128 x);
+  ALM_API __m128 amd_vrs4_sinf (__m128 x);
 
   /**
    * @brief Computes cosine for two double-precision lanes.
    * @param x Vector of two angles in radians.
    * @return Vector of cosines.
    */
-  __m128d amd_vrd2_cos (__m128d x);
+  ALM_API __m128d amd_vrd2_cos (__m128d x);
   /**
    * @brief Computes cosine for four single-precision lanes.
    * @param x Vector of four angles in radians.
    * @return Vector of cosines.
    */
-  __m128 amd_vrs4_cosf (__m128 x);
+  ALM_API __m128 amd_vrs4_cosf (__m128 x);
 
   /**
    * @brief Computes tangent for two double-precision lanes.
    * @param x Vector of two angles in radians.
    * @return Vector of tangents.
    */
-  __m128d amd_vrd2_tan (__m128d x);
+  ALM_API __m128d amd_vrd2_tan (__m128d x);
   /**
    * @brief Computes tangent for four single-precision lanes.
    * @param x Vector of four angles in radians.
    * @return Vector of tangents.
    */
-  __m128 amd_vrs4_tanf (__m128 x);
+  ALM_API __m128 amd_vrs4_tanf (__m128 x);
 
   /**
    * @brief Computes both sine and cosine for two double-precision lanes.
@@ -230,14 +245,14 @@ extern "C" {
    * @param sin Output pointer for vector of sines.
    * @param cos Output pointer for vector of cosines.
    */
-  void amd_vrd2_sincos (__m128d x, __m128d *sin, __m128d *cos);
+  ALM_API void amd_vrd2_sincos (__m128d x, __m128d *sin, __m128d *cos);
   /**
    * @brief Computes both sine and cosine for four single-precision lanes.
    * @param x Vector of four angles in radians.
    * @param sin Output pointer for vector of sines.
    * @param cos Output pointer for vector of cosines.
    */
-  void amd_vrs4_sincosf (__m128 x, __m128 *sin, __m128 *cos);
+  ALM_API void amd_vrs4_sincosf (__m128 x, __m128 *sin, __m128 *cos);
 
 /* Inverse Trigonometric */
   /**
@@ -245,39 +260,39 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of arc-sines in radians.
    */
-  __m128d amd_vrd2_asin (__m128d x);
+  ALM_API __m128d amd_vrd2_asin (__m128d x);
   /**
    * @brief Computes arc-sine for four single-precision lanes.
    * @param x Input vector.
    * @return Vector of arc-sines in radians.
    */
-  __m128 amd_vrs4_asinf (__m128 x);
+  ALM_API __m128 amd_vrs4_asinf (__m128 x);
 
   /**
    * @brief Computes arc-cosine for two double-precision lanes.
    * @param x Input vector.
    * @return Vector of arc-cosines in radians.
    */
-  __m128d amd_vrd2_acos (__m128d x);
+  ALM_API __m128d amd_vrd2_acos (__m128d x);
   /**
    * @brief Computes arc-cosine for four single-precision lanes.
    * @param x Input vector.
    * @return Vector of arc-cosines in radians.
    */
-  __m128 amd_vrs4_acosf (__m128 x);
+  ALM_API __m128 amd_vrs4_acosf (__m128 x);
 
   /**
    * @brief Computes arc-tangent for two double-precision lanes.
    * @param x Input vector.
    * @return Vector of arc-tangents in radians.
    */
-  __m128d amd_vrd2_atan (__m128d x);
+  ALM_API __m128d amd_vrd2_atan (__m128d x);
   /**
    * @brief Computes arc-tangent for four single-precision lanes.
    * @param x Input vector.
    * @return Vector of arc-tangents in radians.
    */
-  __m128 amd_vrs4_atanf (__m128 x);
+  ALM_API __m128 amd_vrs4_atanf (__m128 x);
 
 /* Hyperbolic */
   /**
@@ -285,20 +300,20 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of cosh values.
    */
-  __m128d amd_vrd2_cosh (__m128d x);
+  ALM_API __m128d amd_vrd2_cosh (__m128d x);
   /**
    * @brief Computes hyperbolic cosine for four single-precision lanes.
    * @param x Input vector.
    * @return Vector of cosh values.
    */
-  __m128 amd_vrs4_coshf (__m128 x);
+  ALM_API __m128 amd_vrs4_coshf (__m128 x);
 
   /**
    * @brief Computes hyperbolic tangent for four single-precision lanes.
    * @param x Input vector.
    * @return Vector of tanh values.
    */
-  __m128 amd_vrs4_tanhf (__m128 x);
+  ALM_API __m128 amd_vrs4_tanhf (__m128 x);
 
 /* Exponential */
   /**
@@ -306,45 +321,45 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of exponentials.
    */
-  __m128d amd_vrd2_exp (__m128d x);
+  ALM_API __m128d amd_vrd2_exp (__m128d x);
   /**
    * @brief Computes e^x for four single-precision lanes.
    * @param x Input vector.
    * @return Vector of exponentials.
    */
-  __m128 amd_vrs4_expf (__m128 x);
+  ALM_API __m128 amd_vrs4_expf (__m128 x);
 
   /**
    * @brief Computes 2^x for two double-precision lanes.
    * @param x Input vector.
    * @return Vector of base-2 exponentials.
    */
-  __m128d amd_vrd2_exp2 (__m128d x);
+  ALM_API __m128d amd_vrd2_exp2 (__m128d x);
   /**
    * @brief Computes 2^x for four single-precision lanes.
    * @param x Input vector.
    * @return Vector of base-2 exponentials.
    */
-  __m128 amd_vrs4_exp2f (__m128 x);
+  ALM_API __m128 amd_vrs4_exp2f (__m128 x);
 
   /**
    * @brief Computes 10^x for two double-precision lanes.
    * @param x Input vector.
    * @return Vector of base-10 exponentials.
    */
-  __m128d amd_vrd2_exp10 (__m128d x);
+  ALM_API __m128d amd_vrd2_exp10 (__m128d x);
   /**
    * @brief Computes 10^x for four single-precision lanes.
    * @param x Input vector.
    * @return Vector of base-10 exponentials.
    */
-  __m128 amd_vrs4_exp10f (__m128 x);
+  ALM_API __m128 amd_vrs4_exp10f (__m128 x);
   /**
    * @brief Computes exp(x)-1 for four single-precision lanes.
    * @param x Input vector.
    * @return Vector of expm1 values.
    */
-  __m128 amd_vrs4_expm1f (__m128 x);
+  ALM_API __m128 amd_vrs4_expm1f (__m128 x);
 
 
 /* Logarithmic */
@@ -353,52 +368,52 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of ln values.
    */
-  __m128d amd_vrd2_log (__m128d x);
+  ALM_API __m128d amd_vrd2_log (__m128d x);
   /**
    * @brief Computes natural logarithm for four single-precision lanes.
    * @param x Input vector.
    * @return Vector of ln values.
    */
-  __m128 amd_vrs4_logf (__m128 x);
+  ALM_API __m128 amd_vrs4_logf (__m128 x);
 
   /**
    * @brief Computes base-2 logarithm for two double-precision lanes.
    * @param x Input vector.
    * @return Vector of log2 values.
    */
-  __m128d amd_vrd2_log2 (__m128d x);
+  ALM_API __m128d amd_vrd2_log2 (__m128d x);
   /**
    * @brief Computes base-2 logarithm for four single-precision lanes.
    * @param x Input vector.
    * @return Vector of log2 values.
    */
-  __m128 amd_vrs4_log2f (__m128 x);
+  ALM_API __m128 amd_vrs4_log2f (__m128 x);
 
   /**
    * @brief Computes base-10 logarithm for two double-precision lanes.
    * @param x Input vector.
    * @return Vector of log10 values.
    */
-  __m128d amd_vrd2_log10 (__m128d x);
+  ALM_API __m128d amd_vrd2_log10 (__m128d x);
   /**
    * @brief Computes base-10 logarithm for four single-precision lanes.
    * @param x Input vector.
    * @return Vector of log10 values.
    */
-  __m128 amd_vrs4_log10f (__m128 x);
+  ALM_API __m128 amd_vrs4_log10f (__m128 x);
 
   /**
    * @brief Computes log(1+x) for two double-precision lanes.
    * @param x Input vector.
    * @return Vector of log1p values.
    */
-  __m128d amd_vrd2_log1p (__m128d x);
+  ALM_API __m128d amd_vrd2_log1p (__m128d x);
   /**
    * @brief Computes log(1+x) for four single-precision lanes.
    * @param x Input vector.
    * @return Vector of log1p values.
    */
-  __m128 amd_vrs4_log1pf (__m128 x);
+  ALM_API __m128 amd_vrs4_log1pf (__m128 x);
 
 
 /* Power & Root */
@@ -408,14 +423,14 @@ extern "C" {
    * @param y Exponent vector.
    * @return Vector of x^y.
    */
-  __m128d amd_vrd2_pow  (__m128d x, __m128d y);
+  ALM_API __m128d amd_vrd2_pow  (__m128d x, __m128d y);
   /**
    * @brief Raises elements of x to powers in y (four single-precision lanes).
    * @param x Base vector.
    * @param y Exponent vector.
    * @return Vector of x^y.
    */
-  __m128 amd_vrs4_powf  (__m128 x, __m128 y);
+  ALM_API __m128 amd_vrs4_powf  (__m128 x, __m128 y);
 
   /**
    * @brief Raises elements of x to a scalar double-precision exponent.
@@ -423,40 +438,40 @@ extern "C" {
    * @param y Scalar exponent.
    * @return Vector of x^y.
    */
-  __m128d amd_vrd2_powx (__m128d x, double y);
+  ALM_API __m128d amd_vrd2_powx (__m128d x, double y);
   /**
    * @brief Raises elements of x to a scalar single-precision exponent.
    * @param x Base vector.
    * @param y Scalar exponent.
    * @return Vector of x^y.
    */
-  __m128 amd_vrs4_powxf (__m128 x, float y);
+  ALM_API __m128 amd_vrs4_powxf (__m128 x, float y);
 
   /**
    * @brief Computes square root per-lane for two double-precision elements.
    * @param x Input vector.
    * @return Vector of square roots.
    */
-  __m128d amd_vrd2_sqrt (__m128d x);
+  ALM_API __m128d amd_vrd2_sqrt (__m128d x);
   /**
    * @brief Computes square root per-lane for four single-precision elements.
    * @param x Input vector.
    * @return Vector of square roots.
    */
-  __m128 amd_vrs4_sqrtf (__m128 x);
+  ALM_API __m128 amd_vrs4_sqrtf (__m128 x);
 
   /**
    * @brief Computes cube root per-lane for two double-precision elements.
    * @param x Input vector.
    * @return Vector of cube roots.
    */
-  __m128d amd_vrd2_cbrt (__m128d x);
+  ALM_API __m128d amd_vrd2_cbrt (__m128d x);
   /**
    * @brief Computes cube root per-lane for four single-precision elements.
    * @param x Input vector.
    * @return Vector of cube roots.
    */
-  __m128 amd_vrs4_cbrtf (__m128 x);
+  ALM_API __m128 amd_vrs4_cbrtf (__m128 x);
 
 
 /* Error */
@@ -465,13 +480,13 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of erf values.
    */
-  __m128d amd_vrd2_erf (__m128d x);
+  ALM_API __m128d amd_vrd2_erf (__m128d x);
   /**
    * @brief Computes erf per-lane for four single-precision elements.
    * @param x Input vector.
    * @return Vector of erf values.
    */
-  __m128 amd_vrs4_erff (__m128 x);
+  ALM_API __m128 amd_vrs4_erff (__m128 x);
 
 /* Complementary Error */
   /**
@@ -479,13 +494,13 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of erfc values.
    */
-  __m128d amd_vrd2_erfc (__m128d x);
+  ALM_API __m128d amd_vrd2_erfc (__m128d x);
   /**
    * @brief Computes erfc per-lane for four single-precision elements.
    * @param x Input vector.
    * @return Vector of erfc values.
    */
-  __m128 amd_vrs4_erfcf (__m128 x);
+  ALM_API __m128 amd_vrs4_erfcf (__m128 x);
 
 /* Inverse Error */
   /**
@@ -493,20 +508,20 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of erfinv values.
    */
-  __m128d amd_vrd2_erfinv (__m128d x);
+  ALM_API __m128d amd_vrd2_erfinv (__m128d x);
   /**
    * @brief Computes Inverse Error function per-lane for four double-precision elements.
    * @param x Input vector.
    * @return Vector of erfinv values.
    */
-  __m256d amd_vrd4_erfinv (__m256d x);
+  ALM_API __m256d amd_vrd4_erfinv (__m256d x);
 /* Inverse Complementary Error */
   /**
    * @brief Computes erfcinv per-lane for two double-precision elements.
    * @param x Input vector.
    * @return Vector of erfcinv values.
    */
-  __m128d amd_vrd2_erfcinv (__m128d x);
+  ALM_API __m128d amd_vrd2_erfcinv (__m128d x);
 
 /* Inverse Cumulative Normal Distribution */
   /**
@@ -514,20 +529,20 @@ extern "C" {
    * @param x Input vector with values in (0, 1).
    * @return Vector of cdfnorminv values.
    */
-  __m128d amd_vrd2_cdfnorminv (__m128d x);
+  ALM_API __m128d amd_vrd2_cdfnorminv (__m128d x);
 /* Remainder */
   /**
    * @brief Computes absolute value per-lane for two double-precision elements.
    * @param x Input vector.
    * @return Vector of absolute values.
    */
-  __m128d amd_vrd2_fabs (__m128d x);
+  ALM_API __m128d amd_vrd2_fabs (__m128d x);
   /**
    * @brief Computes absolute value per-lane for four single-precision elements.
    * @param x Input vector.
    * @return Vector of absolute values.
    */
-  __m128 amd_vrs4_fabsf (__m128 x);
+  ALM_API __m128 amd_vrs4_fabsf (__m128 x);
 
 /* Nearest Integer */
   /**
@@ -535,13 +550,13 @@ extern "C" {
    * @param x Input vector x.
    * @return Vector of rounded value.
    */
-  __m128d amd_vrd2_round (__m128d x);
+  ALM_API __m128d amd_vrd2_round (__m128d x);
   /**
    * @brief Computes round per-lane for four single-precision elements.
    * @param x Input vector x.
    * @return Vector of rounded value.
    */
-  __m128 amd_vrs4_roundf (__m128 x);
+  ALM_API __m128 amd_vrs4_roundf (__m128 x);
 
 /* Cumulative Normal Distribution */
   /**
@@ -549,7 +564,7 @@ extern "C" {
    * @param x Input vector x
    * @return Vector of cdfnorm values
    */
-  __m128d amd_vrd2_cdfnorm (__m128d x);
+  ALM_API __m128d amd_vrd2_cdfnorm (__m128d x);
 
 /* Linearfrac */
   /**
@@ -562,7 +577,7 @@ extern "C" {
    * @param shy Shift for y.
    * @return Result vector of the transform.
    */
-  __m128d amd_vrd2_linearfrac (__m128d x, __m128d y,
+  ALM_API __m128d amd_vrd2_linearfrac (__m128d x, __m128d y,
                                double scx, double shx,
                                double scy, double shy);
 
@@ -576,7 +591,7 @@ extern "C" {
    * @param shy Shift for y.
    * @return Result vector of the transform.
    */
-  __m128 amd_vrs4_linearfracf (__m128 x, __m128 y,
+  ALM_API __m128 amd_vrs4_linearfracf (__m128 x, __m128 y,
                                float scx, float shx,
                                float scy, float shy);
 
@@ -590,39 +605,39 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of sines.
    */
-  __m256d amd_vrd4_sin (__m256d x);
+  ALM_API __m256d amd_vrd4_sin (__m256d x);
   /**
    * @brief Computes sine for eight single-precision lanes.
    * @param x Input vector.
    * @return Vector of sines.
    */
-  __m256 amd_vrs8_sinf (__m256 x);
+  ALM_API __m256 amd_vrs8_sinf (__m256 x);
 
   /**
    * @brief Computes cosine for four double-precision lanes.
    * @param x Input vector.
    * @return Vector of cosines.
    */
-  __m256d amd_vrd4_cos (__m256d x);
+  ALM_API __m256d amd_vrd4_cos (__m256d x);
   /**
    * @brief Computes cosine for eight single-precision lanes.
    * @param x Input vector.
    * @return Vector of cosines.
    */
-  __m256 amd_vrs8_cosf (__m256 x);
+  ALM_API __m256 amd_vrs8_cosf (__m256 x);
 
   /**
    * @brief Computes tangent for four double-precision lanes.
    * @param x Input vector.
    * @return Vector of tangents.
    */
-  __m256d amd_vrd4_tan (__m256d x);
+  ALM_API __m256d amd_vrd4_tan (__m256d x);
   /**
    * @brief Computes tangent for eight single-precision lanes.
    * @param x Input vector.
    * @return Vector of tangents.
    */
-  __m256 amd_vrs8_tanf (__m256 x);
+  ALM_API __m256 amd_vrs8_tanf (__m256 x);
 
   /**
    * @brief Computes both sine and cosine per-lane for four double-precision elements.
@@ -630,14 +645,14 @@ extern "C" {
    * @param sin Output pointer for sines.
    * @param cos Output pointer for cosines.
    */
-  void amd_vrd4_sincos (__m256d x, __m256d *sin, __m256d *cos);
+  ALM_API void amd_vrd4_sincos (__m256d x, __m256d *sin, __m256d *cos);
   /**
    * @brief Computes both sine and cosine per-lane for eight single-precision elements.
    * @param x Input vector.
    * @param sin Output pointer for sines.
    * @param cos Output pointer for cosines.
    */
-  void amd_vrs8_sincosf (__m256 x, __m256 *sin, __m256 *cos);
+  ALM_API void amd_vrs8_sincosf (__m256 x, __m256 *sin, __m256 *cos);
 
 /* Inverse Trigonometric */
   /**
@@ -645,39 +660,39 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of arc-sines in radians.
    */
-  __m256d amd_vrd4_asin (__m256d x);
+  ALM_API __m256d amd_vrd4_asin (__m256d x);
   /**
    * @brief Computes arc-sine for eight single-precision lanes.
    * @param x Input vector.
    * @return Vector of arc-sines in radians.
    */
-  __m256 amd_vrs8_asinf (__m256 x);
+  ALM_API __m256 amd_vrs8_asinf (__m256 x);
 
   /**
    * @brief Computes arc-cosine for four double-precision lanes.
    * @param x Input vector.
    * @return Vector of arc-cosines in radians.
    */
-  __m256d amd_vrd4_acos (__m256d x);
+  ALM_API __m256d amd_vrd4_acos (__m256d x);
   /**
    * @brief Computes arc-cosine for eight single-precision lanes.
    * @param x Input vector.
    * @return Vector of arc-cosines in radians.
    */
-  __m256 amd_vrs8_acosf (__m256 x);
+  ALM_API __m256 amd_vrs8_acosf (__m256 x);
 
   /**
    * @brief Computes arc-tangent for four double-precision lanes.
    * @param x Input vector.
    * @return Vector of arc-tangents in radians.
    */
-  __m256d amd_vrd4_atan (__m256d x);
+  ALM_API __m256d amd_vrd4_atan (__m256d x);
   /**
    * @brief Computes arc-tangent for eight single-precision lanes.
    * @param x Input vector.
    * @return Vector of arc-tangents in radians.
    */
-  __m256 amd_vrs8_atanf (__m256 x);
+  ALM_API __m256 amd_vrs8_atanf (__m256 x);
 
 
 /* Hyperbolic */
@@ -686,13 +701,13 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of cosh values.
    */
-  __m256 amd_vrs8_coshf (__m256 x);
+  ALM_API __m256 amd_vrs8_coshf (__m256 x);
   /**
    * @brief Computes hyperbolic tangent for eight single-precision lanes.
    * @param x Input vector.
    * @return Vector of tanh values.
    */
-  __m256 amd_vrs8_tanhf (__m256 x);
+  ALM_API __m256 amd_vrs8_tanhf (__m256 x);
 
 /* Exponential */
   /**
@@ -700,26 +715,26 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of exponentials.
    */
-  __m256d amd_vrd4_exp (__m256d x);
+  ALM_API __m256d amd_vrd4_exp (__m256d x);
   /**
    * @brief Computes e^x for eight single-precision lanes.
    * @param x Input vector.
    * @return Vector of exponentials.
    */
-  __m256 amd_vrs8_expf (__m256 x);
+  ALM_API __m256 amd_vrs8_expf (__m256 x);
 
   /**
    * @brief Computes 2^x for four double-precision lanes.
    * @param x Input vector.
    * @return Vector of base-2 exponentials.
    */
-  __m256d amd_vrd4_exp2 (__m256d x);
+  ALM_API __m256d amd_vrd4_exp2 (__m256d x);
   /**
    * @brief Computes 2^x for eight single-precision lanes.
    * @param x Input vector.
    * @return Vector of base-2 exponentials.
    */
-  __m256 amd_vrs8_exp2f (__m256 x);
+  ALM_API __m256 amd_vrs8_exp2f (__m256 x);
 
 /* Logarithmic */
   /**
@@ -727,33 +742,33 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of ln values.
    */
-  __m256d amd_vrd4_log (__m256d x);
+  ALM_API __m256d amd_vrd4_log (__m256d x);
   /**
    * @brief Computes natural logarithm for eight single-precision lanes.
    * @param x Input vector.
    * @return Vector of ln values.
    */
-  __m256 amd_vrs8_logf (__m256 x);
+  ALM_API __m256 amd_vrs8_logf (__m256 x);
 
   /**
    * @brief Computes base-2 logarithm for four double-precision lanes.
    * @param x Input vector.
    * @return Vector of log2 values.
    */
-  __m256d amd_vrd4_log2 (__m256d x);
+  ALM_API __m256d amd_vrd4_log2 (__m256d x);
   /**
    * @brief Computes base-2 logarithm for eight single-precision lanes.
    * @param x Input vector.
    * @return Vector of log2 values.
    */
-  __m256 amd_vrs8_log2f (__m256 x);
+  ALM_API __m256 amd_vrs8_log2f (__m256 x);
 
   /**
    * @brief Computes base-10 logarithm for eight single-precision lanes.
    * @param x Input vector.
    * @return Vector of log10 values.
    */
-  __m256 amd_vrs8_log10f (__m256 x);
+  ALM_API __m256 amd_vrs8_log10f (__m256 x);
 
 /* Power & Root */
   /**
@@ -762,14 +777,14 @@ extern "C" {
    * @param y Exponent vector.
    * @return Vector of x^y.
    */
-  __m256d amd_vrd4_pow (__m256d x, __m256d y);
+  ALM_API __m256d amd_vrd4_pow (__m256d x, __m256d y);
   /**
    * @brief Raises elements of x to powers in y (eight single-precision lanes).
    * @param x Base vector.
    * @param y Exponent vector.
    * @return Vector of x^y.
    */
-  __m256 amd_vrs8_powf (__m256 x, __m256 y);
+  ALM_API __m256 amd_vrs8_powf (__m256 x, __m256 y);
 
   /**
    * @brief Raises elements of x to a scalar double-precision exponent.
@@ -777,27 +792,27 @@ extern "C" {
    * @param y Scalar exponent.
    * @return Vector of x^y.
    */
-  __m256d amd_vrd4_powx (__m256d x, double y);
+  ALM_API __m256d amd_vrd4_powx (__m256d x, double y);
   /**
    * @brief Raises elements of x to a scalar single-precision exponent.
    * @param x Base vector.
    * @param y Scalar exponent.
    * @return Vector of x^y.
    */
-  __m256 amd_vrs8_powxf (__m256 x, float y);
+  ALM_API __m256 amd_vrs8_powxf (__m256 x, float y);
 
   /**
    * @brief Computes square root per-lane for four double-precision elements.
    * @param x Input vector.
    * @return Vector of square roots.
    */
-  __m256d amd_vrd4_sqrt (__m256d x);
+  ALM_API __m256d amd_vrd4_sqrt (__m256d x);
   /**
    * @brief Computes square root per-lane for eight single-precision elements.
    * @param x Input vector.
    * @return Vector of square roots.
    */
-  __m256 amd_vrs8_sqrtf (__m256 x);
+  ALM_API __m256 amd_vrs8_sqrtf (__m256 x);
 
 /* Error */
   /**
@@ -805,13 +820,13 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of erf values.
    */
-  __m256d amd_vrd4_erf (__m256d x);
+  ALM_API __m256d amd_vrd4_erf (__m256d x);
   /**
    * @brief Computes erf per-lane for eight single-precision elements.
    * @param x Input vector.
    * @return Vector of erf values.
    */
-  __m256 amd_vrs8_erff (__m256 x);
+  ALM_API __m256 amd_vrs8_erff (__m256 x);
 
 /* Complementary Error */
   /**
@@ -819,13 +834,13 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of erfc values.
    */
-  __m256d amd_vrd4_erfc (__m256d x);
+  ALM_API __m256d amd_vrd4_erfc (__m256d x);
   /**
    * @brief Computes erfc per-lane for eight single-precision elements.
    * @param x Input vector.
    * @return Vector of erfc values.
    */
-  __m256 amd_vrs8_erfcf (__m256 x);
+  ALM_API __m256 amd_vrs8_erfcf (__m256 x);
 
 /* Cumulative Normal Distribution */
   /**
@@ -833,7 +848,7 @@ extern "C" {
    * @param x Input vector x
    * @return Vector of cdfnorm values
    */
-  __m256d amd_vrd4_cdfnorm (__m256d x);
+  ALM_API __m256d amd_vrd4_cdfnorm (__m256d x);
 
 /* Round */
   /**
@@ -841,14 +856,14 @@ extern "C" {
    * @param x Input vector x.
    * @return Vector of rounded value.
    */
-  __m256 amd_vrs8_roundf (__m256 x);
+  ALM_API __m256 amd_vrs8_roundf (__m256 x);
 /* Inverse Complementary Error */
   /**
    * @brief Computes erfcinv per-lane for four double-precision elements.
    * @param x Input vector.
    * @return Vector of erfcinv values.
    */
-  __m256d amd_vrd4_erfcinv (__m256d x);
+  ALM_API __m256d amd_vrd4_erfcinv (__m256d x);
 
 /* Inverse Cumulative Normal Distribution */
   /**
@@ -856,7 +871,7 @@ extern "C" {
    * @param x Input vector with values in (0, 1).
    * @return Vector of cdfnorminv values.
    */
-  __m256d amd_vrd4_cdfnorminv (__m256d x);
+  ALM_API __m256d amd_vrd4_cdfnorminv (__m256d x);
 
 /* Remainder */
   /**
@@ -864,13 +879,13 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of absolute values.
    */
-  __m256d amd_vrd4_fabs (__m256d x);
+  ALM_API __m256d amd_vrd4_fabs (__m256d x);
   /**
    * @brief Computes absolute value per-lane for eight single-precision elements.
    * @param x Input vector.
    * @return Vector of absolute values.
    */
-  __m256 amd_vrs8_fabsf (__m256 x);
+  ALM_API __m256 amd_vrs8_fabsf (__m256 x);
 
 /* Nearest Integer */
   /**
@@ -878,7 +893,7 @@ extern "C" {
    * @param x Input vector x.
    * @return Vector of rounded value.
    */
-  __m256d amd_vrd4_round (__m256d x);
+  ALM_API __m256d amd_vrd4_round (__m256d x);
 
 /* Linearfrac */
   /**
@@ -891,7 +906,7 @@ extern "C" {
    * @param shy Shift for y.
    * @return Result vector of the transform.
    */
-  __m256d amd_vrd4_linearfrac (__m256d x, __m256d y,
+  ALM_API __m256d amd_vrd4_linearfrac (__m256d x, __m256d y,
                                double scx, double shx,
                                double scy, double shy);
 
@@ -905,7 +920,7 @@ extern "C" {
    * @param shy Shift for y.
    * @return Result vector of the transform.
    */
-  __m256 amd_vrs8_linearfracf (__m256 x, __m256 y,
+  ALM_API __m256 amd_vrs8_linearfracf (__m256 x, __m256 y,
                                float scx, float shx,
                                float scy, float shy);
 #endif /* __AVX2__ */
@@ -918,39 +933,39 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of sines.
    */
-  __m512d amd_vrd8_sin (__m512d x);
+  ALM_API __m512d amd_vrd8_sin (__m512d x);
   /**
    * @brief Computes sine for sixteen single-precision lanes.
    * @param x Input vector.
    * @return Vector of sines.
    */
-  __m512 amd_vrs16_sinf (__m512 x);
+  ALM_API __m512 amd_vrs16_sinf (__m512 x);
 
   /**
    * @brief Computes cosine for eight double-precision lanes.
    * @param x Input vector.
    * @return Vector of cosines.
    */
-  __m512d amd_vrd8_cos (__m512d x);
+  ALM_API __m512d amd_vrd8_cos (__m512d x);
   /**
    * @brief Computes cosine for sixteen single-precision lanes.
    * @param x Input vector.
    * @return Vector of cosines.
    */
-  __m512 amd_vrs16_cosf (__m512 x);
+  ALM_API __m512 amd_vrs16_cosf (__m512 x);
 
   /**
    * @brief Computes tangent for eight double-precision lanes.
    * @param x Input vector.
    * @return Vector of tangents.
    */
-  __m512d amd_vrd8_tan (__m512d x);
+  ALM_API __m512d amd_vrd8_tan (__m512d x);
   /**
    * @brief Computes tangent for sixteen single-precision lanes.
    * @param x Input vector.
    * @return Vector of tangents.
    */
-  __m512 amd_vrs16_tanf (__m512 x);
+  ALM_API __m512 amd_vrs16_tanf (__m512 x);
 
   /**
    * @brief Computes both sine and cosine for eight double-precision lanes.
@@ -958,14 +973,14 @@ extern "C" {
    * @param sin Output pointer for sines.
    * @param cos Output pointer for cosines.
    */
-  void amd_vrd8_sincos (__m512d x, __m512d *sin, __m512d *cos);
+  ALM_API void amd_vrd8_sincos (__m512d x, __m512d *sin, __m512d *cos);
   /**
    * @brief Computes both sine and cosine for sixteen single-precision lanes.
    * @param x Input vector.
    * @param sin Output pointer for sines.
    * @param cos Output pointer for cosines.
    */
-  void amd_vrs16_sincosf (__m512 x, __m512 *sin, __m512 *cos);
+  ALM_API void amd_vrs16_sincosf (__m512 x, __m512 *sin, __m512 *cos);
 
 /* Inverse Trigonometric */
   /**
@@ -973,33 +988,33 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of arc-sines in radians.
    */
-  __m512d amd_vrd8_asin (__m512d x);
+  ALM_API __m512d amd_vrd8_asin (__m512d x);
   /**
    * @brief Computes arc-sine for sixteen single-precision lanes.
    * @param x Input vector.
    * @return Vector of arc-sines in radians.
    */
-  __m512 amd_vrs16_asinf (__m512 x);
+  ALM_API __m512 amd_vrs16_asinf (__m512 x);
 
   /**
    * @brief Computes arc-cosine for sixteen single-precision lanes.
    * @param x Input vector.
    * @return Vector of arc-cosines in radians.
    */
-  __m512 amd_vrs16_acosf (__m512 x);
+  ALM_API __m512 amd_vrs16_acosf (__m512 x);
 
   /**
    * @brief Computes arc-tangent for eight double-precision lanes.
    * @param x Input vector.
    * @return Vector of arc-tangents in radians.
    */
-  __m512d amd_vrd8_atan (__m512d x);
+  ALM_API __m512d amd_vrd8_atan (__m512d x);
   /**
    * @brief Computes arc-tangent for sixteen single-precision lanes.
    * @param x Input vector.
    * @return Vector of arc-tangents in radians.
    */
-  __m512 amd_vrs16_atanf (__m512 x);
+  ALM_API __m512 amd_vrs16_atanf (__m512 x);
 
 /* Hyperbolic */
   /**
@@ -1007,7 +1022,7 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of tanh values.
    */
-  __m512 amd_vrs16_tanhf (__m512 x);
+  ALM_API __m512 amd_vrs16_tanhf (__m512 x);
 
 /* Exponential */
   /**
@@ -1015,26 +1030,26 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of exponentials.
    */
-  __m512d amd_vrd8_exp (__m512d x);
+  ALM_API __m512d amd_vrd8_exp (__m512d x);
   /**
    * @brief Computes e^x for sixteen single-precision lanes.
    * @param x Input vector.
    * @return Vector of exponentials.
    */
-  __m512 amd_vrs16_expf (__m512 x);
+  ALM_API __m512 amd_vrs16_expf (__m512 x);
 
   /**
    * @brief Computes 2^x for eight double-precision lanes.
    * @param x Input vector.
    * @return Vector of base-2 exponentials.
    */
-  __m512d amd_vrd8_exp2 (__m512d x);
+  ALM_API __m512d amd_vrd8_exp2 (__m512d x);
   /**
    * @brief Computes 2^x for sixteen single-precision lanes.
    * @param x Input vector.
    * @return Vector of base-2 exponentials.
    */
-  __m512 amd_vrs16_exp2f (__m512 x);
+  ALM_API __m512 amd_vrs16_exp2f (__m512 x);
 
 /* Logarithmic */
   /**
@@ -1042,33 +1057,33 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of ln values.
    */
-  __m512d amd_vrd8_log (__m512d x);
+  ALM_API __m512d amd_vrd8_log (__m512d x);
   /**
    * @brief Computes natural logarithm for sixteen single-precision lanes.
    * @param x Input vector.
    * @return Vector of ln values.
    */
-  __m512 amd_vrs16_logf (__m512 x);
+  ALM_API __m512 amd_vrs16_logf (__m512 x);
 
   /**
    * @brief Computes base-2 logarithm for eight double-precision lanes.
    * @param x Input vector.
    * @return Vector of log2 values.
    */
-  __m512d amd_vrd8_log2 (__m512d x);
+  ALM_API __m512d amd_vrd8_log2 (__m512d x);
   /**
    * @brief Computes base-2 logarithm for sixteen single-precision lanes.
    * @param x Input vector.
    * @return Vector of log2 values.
    */
-  __m512 amd_vrs16_log2f (__m512 x);
+  ALM_API __m512 amd_vrs16_log2f (__m512 x);
 
   /**
    * @brief Computes base-10 logarithm for sixteen single-precision lanes.
    * @param x Input vector.
    * @return Vector of log10 values.
    */
-  __m512 amd_vrs16_log10f (__m512 x);
+  ALM_API __m512 amd_vrs16_log10f (__m512 x);
 
 /* Power & Root */
   /**
@@ -1077,14 +1092,14 @@ extern "C" {
    * @param y Exponent vector.
    * @return Vector of x^y.
    */
-  __m512d amd_vrd8_pow (__m512d x, __m512d y);
+  ALM_API __m512d amd_vrd8_pow (__m512d x, __m512d y);
   /**
    * @brief Raises elements of x to powers in y (sixteen single-precision lanes).
    * @param x Base vector.
    * @param y Exponent vector.
    * @return Vector of x^y.
    */
-  __m512 amd_vrs16_powf (__m512 x, __m512 y);
+  ALM_API __m512 amd_vrs16_powf (__m512 x, __m512 y);
 
   /**
    * @brief Raises elements of x to a scalar double-precision exponent.
@@ -1092,27 +1107,27 @@ extern "C" {
    * @param y Scalar exponent.
    * @return Vector of x^y.
    */
-  __m512d amd_vrd8_powx (__m512d x, double y);
+  ALM_API __m512d amd_vrd8_powx (__m512d x, double y);
   /**
    * @brief Raises elements of x to a scalar single-precision exponent.
    * @param x Base vector.
    * @param y Scalar exponent.
    * @return Vector of x^y.
    */
-  __m512 amd_vrs16_powxf (__m512 x, float y);
+  ALM_API __m512 amd_vrs16_powxf (__m512 x, float y);
 
   /**
    * @brief Computes square root per-lane for eight double-precision elements.
    * @param x Input vector.
    * @return Vector of square roots.
    */
-  __m512d amd_vrd8_sqrt (__m512d x);
+  ALM_API __m512d amd_vrd8_sqrt (__m512d x);
   /**
    * @brief Computes square root per-lane for sixteen single-precision elements.
    * @param x Input vector.
    * @return Vector of square roots.
    */
-  __m512 amd_vrs16_sqrtf (__m512 x);
+  ALM_API __m512 amd_vrs16_sqrtf (__m512 x);
 
 /* Error */
   /**
@@ -1120,13 +1135,13 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of erf values.
    */
-  __m512d amd_vrd8_erf (__m512d x);
+  ALM_API __m512d amd_vrd8_erf (__m512d x);
   /**
    * @brief Computes erf per-lane for sixteen single-precision elements.
    * @param x Input vector.
    * @return Vector of erf values.
    */
-  __m512 amd_vrs16_erff (__m512 x);
+  ALM_API __m512 amd_vrs16_erff (__m512 x);
 
 /* Complementary Error */
   /**
@@ -1134,13 +1149,13 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of erfc values.
    */
-  __m512d amd_vrd8_erfc (__m512d x);
+  ALM_API __m512d amd_vrd8_erfc (__m512d x);
   /**
    * @brief Computes erfc per-lane for sixteen single-precision elements.
    * @param x Input vector.
    * @return Vector of erfc values.
    */
-  __m512 amd_vrs16_erfcf (__m512 x);
+  ALM_API __m512 amd_vrs16_erfcf (__m512 x);
 
 /* Inverse Error */
   /**
@@ -1148,7 +1163,7 @@ extern "C" {
    * @param x Input vector.
    * @return Vector of erfinv values.
    */
-  __m512d amd_vrd8_erfinv (__m512d x);
+  ALM_API __m512d amd_vrd8_erfinv (__m512d x);
 
 /* Cumulative Normal Distribution */
   /**
@@ -1156,7 +1171,7 @@ extern "C" {
    * @param x Input vector x
    * @return Vector of cdfnorm values
    */
-  __m512d amd_vrd8_cdfnorm (__m512d x);
+  ALM_API __m512d amd_vrd8_cdfnorm (__m512d x);
 
 /* Nearest Integer */
   /**
@@ -1164,20 +1179,20 @@ extern "C" {
    * @param x Input vector x.
    * @return Vector of rounded value.
    */
-  __m512d amd_vrd8_round (__m512d x);
+  ALM_API __m512d amd_vrd8_round (__m512d x);
   /**
    * @brief Computes round per-lane for sixteen single-precision elements.
    * @param x Input vector x.
    * @return Vector of rounded value.
    */
-  __m512 amd_vrs16_roundf (__m512 x);
+  ALM_API __m512 amd_vrs16_roundf (__m512 x);
 /* Inverse Complementary Error */
   /**
    * @brief Computes erfcinv per-lane for eight double-precision elements.
    * @param x Input vector.
    * @return Vector of erfcinv values.
    */
-  __m512d amd_vrd8_erfcinv (__m512d x);
+  ALM_API __m512d amd_vrd8_erfcinv (__m512d x);
 
 /* Inverse Cumulative Normal Distribution */
   /**
@@ -1185,7 +1200,7 @@ extern "C" {
    * @param x Input vector with values in (0, 1).
    * @return Vector of cdfnorminv values.
    */
-  __m512d amd_vrd8_cdfnorminv (__m512d x);
+  ALM_API __m512d amd_vrd8_cdfnorminv (__m512d x);
 
 /* Linearfrac */
   /**
@@ -1198,7 +1213,7 @@ extern "C" {
    * @param shy Shift for y.
    * @return Result vector of the transform.
    */
-  __m512d amd_vrd8_linearfrac (__m512d x, __m512d y,
+  ALM_API __m512d amd_vrd8_linearfrac (__m512d x, __m512d y,
                                 double scx, double shx,
                                 double scy, double shy);
 
@@ -1212,7 +1227,7 @@ extern "C" {
    * @param shy Shift for y.
    * @return Result vector of the transform.
    */
-  __m512 amd_vrs16_linearfracf (__m512 x, __m512 y,
+  ALM_API __m512 amd_vrs16_linearfracf (__m512 x, __m512 y,
                                  float scx, float shx,
                                  float scy, float shy);
 #endif /* __AVX512F__ */
@@ -1230,14 +1245,14 @@ extern "C" {
    * @param src Input array of length len.
    * @param dst Output array of length len for sines.
    */
-  void amd_vrda_sin (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_sin (int len, const double *src, double *dst);
   /**
    * @brief Computes sine elementwise for float array.
    * @param len Number of elements.
    * @param src Input array of length len.
    * @param dst Output array of length len for sines.
    */
-  void amd_vrsa_sinf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_sinf (int len, const float *src, float *dst);
 
   /**
    * @brief Computes cosine elementwise for double array.
@@ -1245,14 +1260,14 @@ extern "C" {
    * @param src Input array of length len.
    * @param dst Output array of length len for cosines.
    */
-  void amd_vrda_cos (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_cos (int len, const double *src, double *dst);
   /**
    * @brief Computes cosine elementwise for float array.
    * @param len Number of elements.
    * @param src Input array of length len.
    * @param dst Output array of length len for cosines.
    */
-  void amd_vrsa_cosf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_cosf (int len, const float *src, float *dst);
 
   /**
    * @brief Computes tangent elementwise for double array.
@@ -1260,14 +1275,14 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array for tangents.
    */
-  void amd_vrda_tan (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_tan (int len, const double *src, double *dst);
   /**
    * @brief Computes tangent elementwise for float array.
    * @param len Number of elements.
    * @param src Input array.
    * @param dst Output array for tangents.
    */
-  void amd_vrsa_tanf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_tanf (int len, const float *src, float *dst);
 
   /**
    * @brief Computes sine and cosine elementwise for double array.
@@ -1276,7 +1291,7 @@ extern "C" {
    * @param sin Output array for sines.
    * @param cos Output array for cosines.
    */
-  void amd_vrda_sincos (int len, const double *src, double *sin, double *cos);
+  ALM_API void amd_vrda_sincos (int len, const double *src, double *sin, double *cos);
   /**
    * @brief Computes sine and cosine elementwise for float array.
    * @param len Number of elements.
@@ -1284,7 +1299,7 @@ extern "C" {
    * @param sin Output array for sines.
    * @param cos Output array for cosines.
    */
-  void amd_vrsa_sincosf (int len, const float *src, float *sin, float *cos);
+  ALM_API void amd_vrsa_sincosf (int len, const float *src, float *sin, float *cos);
 #endif
 
 
@@ -1296,14 +1311,14 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array for arc-sines in radians.
    */
-  void amd_vrda_asin (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_asin (int len, const double *src, double *dst);
   /**
    * @brief Computes arc-sine elementwise for float array.
    * @param len Number of elements.
    * @param src Input array.
    * @param dst Output array for arc-sines in radians.
    */
-  void amd_vrsa_asinf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_asinf (int len, const float *src, float *dst);
 
   /**
    * @brief Computes arc-cosine elementwise for double array.
@@ -1311,14 +1326,14 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array for arc-cosines in radians.
    */
-  void amd_vrda_acos (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_acos (int len, const double *src, double *dst);
   /**
    * @brief Computes arc-cosine elementwise for float array.
    * @param len Number of elements.
    * @param src Input array.
    * @param dst Output array for arc-cosines in radians.
    */
-  void amd_vrsa_acosf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_acosf (int len, const float *src, float *dst);
 
   /**
    * @brief Computes arc-tangent elementwise for double array.
@@ -1326,14 +1341,14 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array for arc-tangents in radians.
    */
-  void amd_vrda_atan (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_atan (int len, const double *src, double *dst);
   /**
    * @brief Computes arc-tangent elementwise for float array.
    * @param len Number of elements.
    * @param src Input array.
    * @param dst Output array for arc-tangents in radians.
    */
-  void amd_vrsa_atanf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_atanf (int len, const float *src, float *dst);
 #endif
 
 
@@ -1345,7 +1360,7 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array for cosh values.
    */
-  void amd_vrda_cosh (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_cosh (int len, const double *src, double *dst);
 #endif
 
 #if defined (__AVX2__)
@@ -1355,14 +1370,14 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array for cosh values.
    */
-  void amd_vrsa_coshf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_coshf (int len, const float *src, float *dst);
   /**
    * @brief Computes hyperbolic tangent elementwise for float array.
    * @param len Number of elements.
    * @param src Input array.
    * @param dst Output array for tanh values.
    */
-  void amd_vrsa_tanhf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_tanhf (int len, const float *src, float *dst);
 #endif
 
 
@@ -1374,14 +1389,14 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of exponentials.
    */
-  void amd_vrda_exp (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_exp (int len, const double *src, double *dst);
   /**
    * @brief Computes e^x elementwise for float array.
    * @param len Number of elements.
    * @param src Input array.
    * @param dst Output array of exponentials.
    */
-  void amd_vrsa_expf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_expf (int len, const float *src, float *dst);
 
   /**
    * @brief Computes 2^x elementwise for double array.
@@ -1389,14 +1404,14 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of base-2 exponentials.
    */
-  void amd_vrda_exp2 (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_exp2 (int len, const double *src, double *dst);
   /**
    * @brief Computes 2^x elementwise for float array.
    * @param len Number of elements.
    * @param src Input array.
    * @param dst Output array of base-2 exponentials.
    */
-  void amd_vrsa_exp2f (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_exp2f (int len, const float *src, float *dst);
 #endif
 
   /**
@@ -1405,7 +1420,7 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of base-10 exponentials.
    */
-  void amd_vrda_exp10  (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_exp10  (int len, const double *src, double *dst);
 
 #if defined (__AVX__)
   /**
@@ -1414,7 +1429,7 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of base-10 exponentials.
    */
-  void amd_vrsa_exp10f (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_exp10f (int len, const float *src, float *dst);
 #endif
 
   /**
@@ -1423,7 +1438,7 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of expm1 values.
    */
-  void amd_vrda_expm1 (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_expm1 (int len, const double *src, double *dst);
 
 
 #if defined (__AVX__)
@@ -1433,7 +1448,7 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of expm1 values.
    */
-  void amd_vrsa_expm1f (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_expm1f (int len, const float *src, float *dst);
 #endif
 
 
@@ -1445,14 +1460,14 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of ln values.
    */
-  void amd_vrda_log (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_log (int len, const double *src, double *dst);
   /**
    * @brief Computes natural logarithm elementwise for float array.
    * @param len Number of elements.
    * @param src Input array.
    * @param dst Output array of ln values.
    */
-  void amd_vrsa_logf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_logf (int len, const float *src, float *dst);
 
   /**
    * @brief Computes base-2 logarithm elementwise for double array.
@@ -1460,14 +1475,14 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of log2 values.
    */
-  void amd_vrda_log2 (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_log2 (int len, const double *src, double *dst);
   /**
    * @brief Computes base-2 logarithm elementwise for float array.
    * @param len Number of elements.
    * @param src Input array.
    * @param dst Output array of log2 values.
    */
-  void amd_vrsa_log2f (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_log2f (int len, const float *src, float *dst);
 #endif
 
   /**
@@ -1476,7 +1491,7 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of log10 values.
    */
-  void amd_vrda_log10 (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_log10 (int len, const double *src, double *dst);
 
 #if defined (__AVX2__)
   /**
@@ -1485,7 +1500,7 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of log10 values.
    */
-  void amd_vrsa_log10f (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_log10f (int len, const float *src, float *dst);
 #endif
 
   /**
@@ -1494,7 +1509,7 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of log1p values.
    */
-  void amd_vrda_log1p (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_log1p (int len, const double *src, double *dst);
 
 #if defined (__AVX__)
   /**
@@ -1503,7 +1518,7 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of log1p values.
    */
-  void amd_vrsa_log1pf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_log1pf (int len, const float *src, float *dst);
 #endif
 
 
@@ -1516,7 +1531,7 @@ extern "C" {
    * @param src2 Exponent array.
    * @param dst Output array of powers.
    */
-  void amd_vrda_pow (int len, const double *src1, const double *src2, double *dst);
+  ALM_API void amd_vrda_pow (int len, const double *src1, const double *src2, double *dst);
   /**
    * @brief Computes elementwise power for float arrays.
    * @param len Number of elements.
@@ -1524,7 +1539,7 @@ extern "C" {
    * @param src2 Exponent array.
    * @param dst Output array of powers.
    */
-  void amd_vrsa_powf (int len, const float *src1, const float *src2, float *dst);
+  ALM_API void amd_vrsa_powf (int len, const float *src1, const float *src2, float *dst);
 
   /**
    * @brief Raises elements of x to a scalar single-precision exponent.
@@ -1533,7 +1548,7 @@ extern "C" {
    * @param y Scalar exponent.
    * @param dst Output array of x^y.
    */
-  void amd_vrsa_powxf(int len, const float *src, float y, float *dst);
+  ALM_API void amd_vrsa_powxf(int len, const float *src, float y, float *dst);
 
   /**
    * @brief Raises elements of x to a scalar double-precision exponent.
@@ -1542,7 +1557,7 @@ extern "C" {
    * @param y Scalar exponent.
    * @param dst Output array of x^y.
    */
-  void amd_vrda_powx(int len, const double *src, double y, double *dst);
+  ALM_API void amd_vrda_powx(int len, const double *src, double y, double *dst);
 
   /**
    * @brief Computes elementwise square root for double array.
@@ -1550,14 +1565,14 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of square roots.
    */
-  void amd_vrda_sqrt (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_sqrt (int len, const double *src, double *dst);
   /**
    * @brief Computes elementwise square root for float array.
    * @param len Number of elements.
    * @param src Input array.
    * @param dst Output array of square roots.
    */
-  void amd_vrsa_sqrtf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_sqrtf (int len, const float *src, float *dst);
 #endif
 
   /**
@@ -1566,7 +1581,7 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of cube roots.
    */
-  void amd_vrda_cbrt (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_cbrt (int len, const double *src, double *dst);
 
 #if defined (__AVX__)
   /**
@@ -1575,7 +1590,7 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of cube roots.
    */
-  void amd_vrsa_cbrtf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_cbrtf (int len, const float *src, float *dst);
 #endif
 
 
@@ -1587,14 +1602,14 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of erf values.
    */
-  void amd_vrda_erf (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_erf (int len, const double *src, double *dst);
   /**
    * @brief Computes erf elementwise for float array.
    * @param len Number of elements.
    * @param src Input array.
    * @param dst Output array of erf values.
    */
-  void amd_vrsa_erff (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_erff (int len, const float *src, float *dst);
 
 /* Complementary Error */
   /**
@@ -1603,21 +1618,21 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of erfc values.
    */
-  void amd_vrda_erfc (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_erfc (int len, const double *src, double *dst);
   /**
    * @brief Computes inverse error function for variable-length double array.
    * @param len Number of elements to process.
    * @param src Source array.
    * @param dst Destination array.
    */
-  void amd_vrda_erfinv (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_erfinv (int len, const double *src, double *dst);
   /**
    * @brief Computes erfc elementwise for float array.
    * @param len Number of elements.
    * @param src Input array.
    * @param dst Output array of erfc values.
    */
-  void amd_vrsa_erfcf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_erfcf (int len, const float *src, float *dst);
 
 /* Cumulative Normal Distribution */
 /**
@@ -1626,7 +1641,7 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of cdfnorm values.
    */
-  void amd_vrda_cdfnorm (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_cdfnorm (int len, const double *src, double *dst);
 
 /* Inverse Cumulative Normal Distribution */
   /**
@@ -1635,7 +1650,7 @@ extern "C" {
    * @param src Input array with values in (0, 1).
    * @param dst Output array of cdfnorminv values.
    */
-  void amd_vrda_cdfnorminv (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_cdfnorminv (int len, const double *src, double *dst);
 /* Inverse Complementary Error */
   /**
    * @brief Computes erfcinv elementwise for double array.
@@ -1643,7 +1658,7 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of erfcinv values.
    */
-  void amd_vrda_erfcinv (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_erfcinv (int len, const double *src, double *dst);
 #endif
 
 
@@ -1655,14 +1670,14 @@ extern "C" {
    * @param src Input array.
    * @param dst Output array of absolute values.
    */
-  void amd_vrda_fabs (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_fabs (int len, const double *src, double *dst);
   /**
    * @brief Computes absolute value elementwise for float array.
    * @param len Number of elements.
    * @param src Input array.
    * @param dst Output array of absolute values.
    */
-  void amd_vrsa_fabsf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_fabsf (int len, const float *src, float *dst);
 
 /* Nearest Integer */
   /**
@@ -1671,14 +1686,14 @@ extern "C" {
    * @param src Input array x.
    * @param dst Output array y.
    */
-  void amd_vrda_round (int len, const double *src, double *dst);
+  ALM_API void amd_vrda_round (int len, const double *src, double *dst);
   /**
    * @brief Computes rounded value elementwise for float array.
    * @param len Number of elements.
    * @param src Input array x.
    * @param dst Output array y.
    */
-  void amd_vrsa_roundf (int len, const float *src, float *dst);
+  ALM_API void amd_vrsa_roundf (int len, const float *src, float *dst);
 
 /* Linearfrac */
   /**
@@ -1692,7 +1707,7 @@ extern "C" {
    * @param shy Shift for y.
    * @param dst Output array for results.
    */
-  void amd_vrda_linearfrac (int len, const double *x, const double *y, double scx,
+  ALM_API void amd_vrda_linearfrac (int len, const double *x, const double *y, double scx,
                             double shx, double scy, double shy, double *dst);
 
   /**
@@ -1706,7 +1721,7 @@ extern "C" {
    * @param shy Shift for y.
    * @param dst Output array for results.
    */
-  void amd_vrsa_linearfracf (int len, const float *x, const float *y, float scx,
+  ALM_API void amd_vrsa_linearfracf (int len, const float *x, const float *y, float scx,
                              float shx, float scy, float shy, float *dst);
 #endif
 
@@ -1719,7 +1734,7 @@ extern "C" {
    * @param rhs Right-hand array.
    * @param dst Output array of maxima.
    */
-  void amd_vrda_fmax (int len, const double *lhs, const double *rhs, double *dst);
+  ALM_API void amd_vrda_fmax (int len, const double *lhs, const double *rhs, double *dst);
   /**
    * @brief Computes elementwise maximum for float arrays.
    * @param len Number of elements.
@@ -1727,7 +1742,7 @@ extern "C" {
    * @param rhs Right-hand array.
    * @param dst Output array of maxima.
    */
-  void amd_vrsa_fmaxf (int len, const float *lhs, const float *rhs, float *dst);
+  ALM_API void amd_vrsa_fmaxf (int len, const float *lhs, const float *rhs, float *dst);
 
   /**
    * @brief Computes elementwise minimum for double arrays.
@@ -1736,7 +1751,7 @@ extern "C" {
    * @param rhs Right-hand array.
    * @param dst Output array of minima.
    */
-  void amd_vrda_fmin (int len, const double *lhs, const double *rhs, double *dst);
+  ALM_API void amd_vrda_fmin (int len, const double *lhs, const double *rhs, double *dst);
   /**
    * @brief Computes elementwise minimum for float arrays.
    * @param len Number of elements.
@@ -1744,7 +1759,7 @@ extern "C" {
    * @param rhs Right-hand array.
    * @param dst Output array of minima.
    */
-  void amd_vrsa_fminf (int len, const float *lhs, const float *rhs, float *dst);
+  ALM_API void amd_vrsa_fminf (int len, const float *lhs, const float *rhs, float *dst);
 
 /* Arithmetic */
   /**
@@ -1754,7 +1769,7 @@ extern "C" {
    * @param rhs Right-hand array.
    * @param dst Output array of sums.
    */
-  void amd_vrda_add (int len, const double *lhs, const double *rhs, double *dst);
+  ALM_API void amd_vrda_add (int len, const double *lhs, const double *rhs, double *dst);
   /**
    * @brief Computes elementwise sum for float arrays.
    * @param len Number of elements.
@@ -1762,7 +1777,7 @@ extern "C" {
    * @param rhs Right-hand array.
    * @param dst Output array of sums.
    */
-  void amd_vrsa_addf (int len, const float *lhs, const float *rhs, float *dst);
+  ALM_API void amd_vrsa_addf (int len, const float *lhs, const float *rhs, float *dst);
 
   /**
    * @brief Computes elementwise difference for double arrays.
@@ -1771,7 +1786,7 @@ extern "C" {
    * @param rhs Right-hand array.
    * @param dst Output array of differences.
    */
-  void amd_vrda_sub (int len, const double *lhs, const double *rhs, double *dst);
+  ALM_API void amd_vrda_sub (int len, const double *lhs, const double *rhs, double *dst);
   /**
    * @brief Computes elementwise difference for float arrays.
    * @param len Number of elements.
@@ -1779,7 +1794,7 @@ extern "C" {
    * @param rhs Right-hand array.
    * @param dst Output array of differences.
    */
-  void amd_vrsa_subf (int len, const float *lhs, const float *rhs, float *dst);
+  ALM_API void amd_vrsa_subf (int len, const float *lhs, const float *rhs, float *dst);
 
   /**
    * @brief Computes elementwise product for double arrays.
@@ -1788,7 +1803,7 @@ extern "C" {
    * @param rhs Right-hand array.
    * @param dst Output array of products.
    */
-  void amd_vrda_mul (int len, const double *lhs, const double *rhs, double *dst);
+  ALM_API void amd_vrda_mul (int len, const double *lhs, const double *rhs, double *dst);
   /**
    * @brief Computes elementwise product for float arrays.
    * @param len Number of elements.
@@ -1796,7 +1811,7 @@ extern "C" {
    * @param rhs Right-hand array.
    * @param dst Output array of products.
    */
-  void amd_vrsa_mulf (int len, const float *lhs, const float *rhs, float *dst);
+  ALM_API void amd_vrsa_mulf (int len, const float *lhs, const float *rhs, float *dst);
 
   /**
    * @brief Computes elementwise quotient for double arrays.
@@ -1805,7 +1820,7 @@ extern "C" {
    * @param rhs Denominator array.
    * @param dst Output array of quotients.
    */
-  void amd_vrda_div (int len, const double *lhs, const double *rhs, double *dst);
+  ALM_API void amd_vrda_div (int len, const double *lhs, const double *rhs, double *dst);
   /**
    * @brief Computes elementwise quotient for float arrays.
    * @param len Number of elements.
@@ -1813,7 +1828,7 @@ extern "C" {
    * @param rhs Denominator array.
    * @param dst Output array of quotients.
    */
-  void amd_vrsa_divf (int len, const float *lhs, const float *rhs, float *dst);
+  ALM_API void amd_vrsa_divf (int len, const float *lhs, const float *rhs, float *dst);
 
 /* Indexed Arithmetic */
   /**
@@ -1826,7 +1841,7 @@ extern "C" {
    * @param dst Output array.
    * @param inc_res Stride for output (in elements).
    */
-  void amd_vrda_addi (int len, const double *lhs, int inc_a,
+  ALM_API void amd_vrda_addi (int len, const double *lhs, int inc_a,
                       const double *rhs, int inc_b, double *dst, int inc_res);
   /**
    * @brief Computes elementwise sum with strides for float arrays.
@@ -1838,7 +1853,7 @@ extern "C" {
    * @param dst Output array.
    * @param inc_res Stride for output (in elements).
    */
-  void amd_vrsa_addfi (int len, const float *lhs, int inc_a,
+  ALM_API void amd_vrsa_addfi (int len, const float *lhs, int inc_a,
                        const float *rhs, int inc_b, float *dst, int inc_res);
 
   /**
@@ -1851,7 +1866,7 @@ extern "C" {
    * @param dst Output array.
    * @param inc_res Stride for output (in elements).
    */
-  void amd_vrda_subi (int len, const double *lhs, int inc_a,
+  ALM_API void amd_vrda_subi (int len, const double *lhs, int inc_a,
                       const double *rhs, int inc_b, double *dst, int inc_res);
   /**
    * @brief Computes elementwise difference with strides for float arrays.
@@ -1863,7 +1878,7 @@ extern "C" {
    * @param dst Output array.
    * @param inc_res Stride for output (in elements).
    */
-  void amd_vrsa_subfi (int len, const float *lhs, int inc_a,
+  ALM_API void amd_vrsa_subfi (int len, const float *lhs, int inc_a,
                        const float *rhs, int inc_b, float *dst, int inc_res );
 
   /**
@@ -1876,7 +1891,7 @@ extern "C" {
    * @param dst Output array.
    * @param inc_res Stride for output (in elements).
    */
-  void amd_vrda_muli (int len, const double *lhs, int inc_a,
+  ALM_API void amd_vrda_muli (int len, const double *lhs, int inc_a,
                       const double *rhs, int inc_b, double *dst, int inc_res);
   /**
    * @brief Computes elementwise product with strides for float arrays.
@@ -1888,7 +1903,7 @@ extern "C" {
    * @param dst Output array.
    * @param inc_res Stride for output (in elements).
    */
-  void amd_vrsa_mulfi (int len, const float *lhs, int inc_a,
+  ALM_API void amd_vrsa_mulfi (int len, const float *lhs, int inc_a,
                        const float *rhs, int inc_b, float *dst, int inc_res);
 
   /**
@@ -1901,7 +1916,7 @@ extern "C" {
    * @param dst Output array.
    * @param inc_res Stride for output (in elements).
    */
-  void amd_vrda_divi (int len, const double *lhs, int inc_a,
+  ALM_API void amd_vrda_divi (int len, const double *lhs, int inc_a,
                       const double *rhs, int inc_b, double *dst, int inc_res);
   /**
    * @brief Computes elementwise quotient with strides for float arrays.
@@ -1913,7 +1928,7 @@ extern "C" {
    * @param dst Output array.
    * @param inc_res Stride for output (in elements).
    */
-  void amd_vrsa_divfi (int len, const float *lhs, int inc_a,
+  ALM_API void amd_vrsa_divfi (int len, const float *lhs, int inc_a,
                        const float *rhs, int inc_b, float *dst, int inc_res);
 
 /* Indexed Maximum & Minimum */
@@ -1927,7 +1942,7 @@ extern "C" {
    * @param dst Output array.
    * @param inc_res Stride for output (in elements).
    */
-  void amd_vrda_fmaxi (int len, const double *lhs, int inc_a,
+  ALM_API void amd_vrda_fmaxi (int len, const double *lhs, int inc_a,
                        const double *rhs, int inc_b, double *dst, int inc_res);
   /**
    * @brief Computes elementwise maximum with strides for float arrays.
@@ -1939,7 +1954,7 @@ extern "C" {
    * @param dst Output array.
    * @param inc_res Stride for output (in elements).
    */
-  void amd_vrsa_fmaxfi (int len, const float *lhs, int inc_a,
+  ALM_API void amd_vrsa_fmaxfi (int len, const float *lhs, int inc_a,
                         const float *rhs, int inc_b, float *dst, int inc_res);
 
   /**
@@ -1952,7 +1967,7 @@ extern "C" {
    * @param dst Output array.
    * @param inc_res Stride for output (in elements).
    */
-  void amd_vrda_fmini (int len, const double *lhs, int inc_a,
+  ALM_API void amd_vrda_fmini (int len, const double *lhs, int inc_a,
                        const double *rhs, int inc_b, double *dst, int inc_res);
   /**
    * @brief Computes elementwise minimum with strides for float arrays.
@@ -1964,7 +1979,7 @@ extern "C" {
    * @param dst Output array.
    * @param inc_res Stride for output (in elements).
    */
-  void amd_vrsa_fminfi (int len, const float *lhs, int inc_a,
+  ALM_API void amd_vrsa_fminfi (int len, const float *lhs, int inc_a,
                         const float *rhs, int inc_b, float *dst, int inc_res);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Optional decoration that marks public AOCL-LibM entry points as imported from `libalm.dll` on Windows. Without this attribute, taking the address of an `amd_*` function (or storing it in a function pointer in a hot loop) captures the local import-thunk address; every call then pays an extra indirect `jmp` through the IAT. For sub-3 ns functions like `amd_expf` that extra hop is ~15-30% of the per-call cost. Decorating the prototypes with `__declspec(dllimport)` tells `MSVC` / `clang-cl` to emit the optimized `movq __imp_*` form, which dereferences the IAT slot once and stores the actual function address - giving a single indirect call per invocation.

This is Opt-in (default is unchanged - no decoration):

> Define `ALM_DLLIMPORT` before `#include <amdlibm.h>` when linking dynamically against `libalm.dll` on Windows to enable the faster call sequence. Safe to leave undefined: behavior is identical to previous releases (no breaking change for callers that link against `libalm-static.lib` or that depend on the existing codegen).

On non-Windows platforms, `ALM_API` decorator is always empty regardless of `ALM_DLLIMPORT`.

-----

Opt-in chosen deliberately to keep the change backward-compatible: existing customers (including all `libalm-static.lib` users) get bit-identical codegen unless they explicitly add `-DALM_DLLIMPORT`. The exports themselves stay on `scripts/libalm.def`, so no `__declspec(dllexport)` is needed in the header.

   Verification on libm_microbench (1-run sanity, build_dllimport/, millions of calls per second):
```
        func    UCRT     AOCL_WIN     AWD old    AWD new
        expf    476.6M   464.7M       293.3M     454.5M   <- recovered
        log2f   473.1M   466.4M       361.7M     464.7M   <- recovered
        expm1   291.3M   335.4M       255.2M     340.3M   <- recovered
        log2    319.4M   454.6M       400.2M     407.0M   <- partial
        log1p   235.1M   325.2M       287.5M     313.7M   <- partial
        hypot   285.0M   227.8M       190.1M     221.7M   <- partial
        remainder 170.1M 252.5M       209.3M     229.1M   <- partial
```   
   The `fp32` B-mechanism cluster (`sinf`, `cosf`, `log10f`, `cbrt`, `pow`) was  unchanged, as predicted - those gaps live in `libalm.dll` itself, not the dispatch path. `lround` did NOT recover (321M -> 325M); worth a closer look in a follow-up. The disassembly flip is confirmed at the `.obj` level: 

  `leaq amd_expf` (capture thunk) -> `movq __imp_amd_expf` (deref IAT slot for actual address).

